### PR TITLE
fix(errors): normalize tool-related error responses consistently (#110)

### DIFF
--- a/internal/providers/anthropic/client_test.go
+++ b/internal/providers/anthropic/client_test.go
@@ -1,0 +1,158 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/marcoantonios1/costguard/internal/providers"
+)
+
+func parseErrorBody(t *testing.T, b []byte) providers.ErrorBody {
+	t.Helper()
+	var out providers.ErrorBody
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("failed to parse normalized error: %v\nbody: %s", err, b)
+	}
+	return out
+}
+
+func newAnthropicClient() *Client {
+	return &Client{}
+}
+
+// ---------------------------------------------------------------------------
+// Generic errors
+// ---------------------------------------------------------------------------
+
+func TestNormalizeError_Anthropic_AuthError(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`)
+	out, err := newAnthropicClient().NormalizeError(http.StatusUnauthorized, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "authentication_error" {
+		t.Errorf("type: got %q, want authentication_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message != "invalid x-api-key" {
+		t.Errorf("message: got %q", parsed.Error.Message)
+	}
+}
+
+func TestNormalizeError_Anthropic_RateLimit(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Rate limit exceeded"}}`)
+	out, err := newAnthropicClient().NormalizeError(http.StatusTooManyRequests, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "rate_limit_error" {
+		t.Errorf("type: got %q, want rate_limit_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_Anthropic_UnparsableBody(t *testing.T) {
+	body := []byte(`not json`)
+	out, err := newAnthropicClient().NormalizeError(http.StatusBadGateway, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "upstream_error" {
+		t.Errorf("type: got %q, want upstream_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty fallback message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tool-related errors
+// ---------------------------------------------------------------------------
+
+func TestNormalizeError_Anthropic_InvalidToolName(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"Invalid tool name: must match ^[a-zA-Z0-9_-]{1,64}$"}}`)
+	out, err := newAnthropicClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty message")
+	}
+}
+
+func TestNormalizeError_Anthropic_ToolSchemaValidation(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"tools.0.input_schema: JSON Schema validation failed. 'properties' must be of type object"}}`)
+	out, err := newAnthropicClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_Anthropic_ToolUseIDNotFound(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"tool_use id toolu_01 not found in tool_use blocks"}}`)
+	out, err := newAnthropicClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty message")
+	}
+}
+
+func TestNormalizeError_Anthropic_MalformedArguments(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"tools[0].input_schema.properties must be an object, got: null"}}`)
+	out, err := newAnthropicClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_Anthropic_OutputIsValidErrorBodyShape(t *testing.T) {
+	// Whatever comes out must always have the {"error":{"message":...}} shape.
+	bodies := [][]byte{
+		[]byte(`{"type":"error","error":{"type":"invalid_request_error","message":"bad tool"}}`),
+		[]byte(`{"type":"error","error":{"type":"","message":"some error"}}`),
+		[]byte(`{}`),
+		[]byte(`not json`),
+	}
+	statuses := []int{400, 400, 500, 502}
+
+	c := newAnthropicClient()
+	for i, body := range bodies {
+		out, err := c.NormalizeError(statuses[i], body)
+		if err != nil {
+			t.Errorf("body[%d]: unexpected error: %v", i, err)
+			continue
+		}
+		var shape struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(out, &shape); err != nil {
+			t.Errorf("body[%d]: output is not valid JSON: %v", i, err)
+			continue
+		}
+		if shape.Error.Message == "" {
+			t.Errorf("body[%d]: error.message is empty", i)
+		}
+	}
+}

--- a/internal/providers/gemini/client.go
+++ b/internal/providers/gemini/client.go
@@ -320,7 +320,7 @@ func (c *Client) NormalizeError(statusCode int, body []byte) ([]byte, error) {
 
 	if err := json.Unmarshal(body, &raw); err == nil && raw.Error.Message != "" {
 		out.Error.Message = raw.Error.Message
-		out.Error.Type = "upstream_error"
+		out.Error.Type = geminiStatusToErrorType(raw.Error.Status)
 		out.Error.Code = raw.Error.Status
 		return json.Marshal(out)
 	}
@@ -328,4 +328,24 @@ func (c *Client) NormalizeError(statusCode int, body []byte) ([]byte, error) {
 	out.Error.Message = http.StatusText(statusCode)
 	out.Error.Type = "upstream_error"
 	return json.Marshal(out)
+}
+
+// geminiStatusToErrorType maps Gemini gRPC status strings to OpenAI error type names.
+func geminiStatusToErrorType(status string) string {
+	switch status {
+	case "INVALID_ARGUMENT":
+		return "invalid_request_error"
+	case "PERMISSION_DENIED":
+		return "permission_error"
+	case "UNAUTHENTICATED":
+		return "authentication_error"
+	case "RESOURCE_EXHAUSTED":
+		return "rate_limit_error"
+	case "NOT_FOUND":
+		return "not_found_error"
+	case "INTERNAL", "UNAVAILABLE":
+		return "api_error"
+	default:
+		return "upstream_error"
+	}
 }

--- a/internal/providers/gemini/client_test.go
+++ b/internal/providers/gemini/client_test.go
@@ -1,0 +1,208 @@
+package gemini
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/marcoantonios1/costguard/internal/providers"
+)
+
+func parseErrorBody(t *testing.T, b []byte) providers.ErrorBody {
+	t.Helper()
+	var out providers.ErrorBody
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("failed to parse normalized error: %v\nbody: %s", err, b)
+	}
+	return out
+}
+
+func newGeminiClient() *Client {
+	return &Client{}
+}
+
+// ---------------------------------------------------------------------------
+// Generic errors
+// ---------------------------------------------------------------------------
+
+func TestNormalizeError_Gemini_AuthError(t *testing.T) {
+	body := []byte(`{"error":{"code":401,"message":"API key not valid. Please pass a valid API key.","status":"UNAUTHENTICATED"}}`)
+	out, err := newGeminiClient().NormalizeError(http.StatusUnauthorized, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "authentication_error" {
+		t.Errorf("type: got %q, want authentication_error", parsed.Error.Type)
+	}
+	if parsed.Error.Code != "UNAUTHENTICATED" {
+		t.Errorf("code: got %q, want UNAUTHENTICATED", parsed.Error.Code)
+	}
+}
+
+func TestNormalizeError_Gemini_RateLimit(t *testing.T) {
+	body := []byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`)
+	out, err := newGeminiClient().NormalizeError(http.StatusTooManyRequests, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "rate_limit_error" {
+		t.Errorf("type: got %q, want rate_limit_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_Gemini_PermissionDenied(t *testing.T) {
+	body := []byte(`{"error":{"code":403,"message":"The caller does not have permission.","status":"PERMISSION_DENIED"}}`)
+	out, err := newGeminiClient().NormalizeError(http.StatusForbidden, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "permission_error" {
+		t.Errorf("type: got %q, want permission_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_Gemini_InternalError(t *testing.T) {
+	body := []byte(`{"error":{"code":500,"message":"Internal error encountered.","status":"INTERNAL"}}`)
+	out, err := newGeminiClient().NormalizeError(http.StatusInternalServerError, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "api_error" {
+		t.Errorf("type: got %q, want api_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_Gemini_UnparsableBody(t *testing.T) {
+	body := []byte(`not json`)
+	out, err := newGeminiClient().NormalizeError(http.StatusBadGateway, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "upstream_error" {
+		t.Errorf("type: got %q, want upstream_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty fallback message")
+	}
+}
+
+func TestNormalizeError_Gemini_UnknownStatus(t *testing.T) {
+	body := []byte(`{"error":{"code":400,"message":"Something weird happened.","status":"UNKNOWN_STATUS"}}`)
+	out, err := newGeminiClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "upstream_error" {
+		t.Errorf("type: got %q, want upstream_error", parsed.Error.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tool-related errors
+// ---------------------------------------------------------------------------
+
+func TestNormalizeError_Gemini_InvalidFunctionName(t *testing.T) {
+	body := []byte(`{"error":{"code":400,"message":"Invalid function name: my-func. Function name must match ^[a-zA-Z_][a-zA-Z0-9_]*$","status":"INVALID_ARGUMENT"}}`)
+	out, err := newGeminiClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+	if parsed.Error.Code != "INVALID_ARGUMENT" {
+		t.Errorf("code: got %q, want INVALID_ARGUMENT", parsed.Error.Code)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty message")
+	}
+}
+
+func TestNormalizeError_Gemini_MalformedFunctionDeclaration(t *testing.T) {
+	body := []byte(`{"error":{"code":400,"message":"Function declaration get_weather is not valid. Schema type ARRAY cannot have properties field.","status":"INVALID_ARGUMENT"}}`)
+	out, err := newGeminiClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_Gemini_FunctionResponseMismatch(t *testing.T) {
+	body := []byte(`{"error":{"code":400,"message":"The model does not support function response messages in this context.","status":"INVALID_ARGUMENT"}}`)
+	out, err := newGeminiClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// geminiStatusToErrorType unit tests
+// ---------------------------------------------------------------------------
+
+func TestGeminiStatusToErrorType(t *testing.T) {
+	cases := []struct {
+		status string
+		want   string
+	}{
+		{"INVALID_ARGUMENT", "invalid_request_error"},
+		{"PERMISSION_DENIED", "permission_error"},
+		{"UNAUTHENTICATED", "authentication_error"},
+		{"RESOURCE_EXHAUSTED", "rate_limit_error"},
+		{"NOT_FOUND", "not_found_error"},
+		{"INTERNAL", "api_error"},
+		{"UNAVAILABLE", "api_error"},
+		{"", "upstream_error"},
+		{"SOME_FUTURE_STATUS", "upstream_error"},
+	}
+	for _, tc := range cases {
+		got := geminiStatusToErrorType(tc.status)
+		if got != tc.want {
+			t.Errorf("geminiStatusToErrorType(%q): got %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeError_Gemini_OutputIsValidErrorBodyShape(t *testing.T) {
+	bodies := [][]byte{
+		[]byte(`{"error":{"code":400,"message":"Invalid function name","status":"INVALID_ARGUMENT"}}`),
+		[]byte(`{"error":{"code":429,"message":"Quota exceeded","status":"RESOURCE_EXHAUSTED"}}`),
+		[]byte(`{}`),
+		[]byte(`not json`),
+	}
+	statuses := []int{400, 429, 500, 502}
+
+	c := newGeminiClient()
+	for i, body := range bodies {
+		out, err := c.NormalizeError(statuses[i], body)
+		if err != nil {
+			t.Errorf("body[%d]: unexpected error: %v", i, err)
+			continue
+		}
+		var shape struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(out, &shape); err != nil {
+			t.Errorf("body[%d]: output is not valid JSON: %v", i, err)
+			continue
+		}
+		if shape.Error.Message == "" {
+			t.Errorf("body[%d]: error.message is empty", i)
+		}
+	}
+}

--- a/internal/providers/openai/client_test.go
+++ b/internal/providers/openai/client_test.go
@@ -1,0 +1,130 @@
+package openai
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/marcoantonios1/costguard/internal/providers"
+)
+
+func parseErrorBody(t *testing.T, b []byte) providers.ErrorBody {
+	t.Helper()
+	var out providers.ErrorBody
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("failed to parse normalized error: %v\nbody: %s", err, b)
+	}
+	return out
+}
+
+func newOpenAIClient() *Client {
+	return &Client{}
+}
+
+// ---------------------------------------------------------------------------
+// Generic errors
+// ---------------------------------------------------------------------------
+
+func TestNormalizeError_OpenAI_AuthError(t *testing.T) {
+	body := []byte(`{"error":{"message":"Incorrect API key provided.","type":"invalid_api_key","code":"invalid_api_key"}}`)
+	out, err := newOpenAIClient().NormalizeError(http.StatusUnauthorized, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_api_key" {
+		t.Errorf("type: got %q, want invalid_api_key", parsed.Error.Type)
+	}
+	if parsed.Error.Message != "Incorrect API key provided." {
+		t.Errorf("message: got %q", parsed.Error.Message)
+	}
+}
+
+func TestNormalizeError_OpenAI_RateLimit(t *testing.T) {
+	body := []byte(`{"error":{"message":"Rate limit reached for model gpt-4o.","type":"requests","code":"rate_limit_exceeded"}}`)
+	out, err := newOpenAIClient().NormalizeError(http.StatusTooManyRequests, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty message")
+	}
+}
+
+func TestNormalizeError_OpenAI_UnparsableBody(t *testing.T) {
+	body := []byte(`not json`)
+	out, err := newOpenAIClient().NormalizeError(http.StatusBadGateway, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "upstream_error" {
+		t.Errorf("type: got %q, want upstream_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty fallback message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tool-related errors
+// ---------------------------------------------------------------------------
+
+func TestNormalizeError_OpenAI_InvalidFunctionArguments(t *testing.T) {
+	body := []byte(`{"error":{"message":"Invalid 'tools[0].function.name': string does not match pattern.","type":"invalid_request_error","code":"invalid_function_name"}}`)
+	out, err := newOpenAIClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty message")
+	}
+}
+
+func TestNormalizeError_OpenAI_MalformedToolSchema(t *testing.T) {
+	body := []byte(`{"error":{"message":"Invalid schema for function 'get_weather': schema must be a JSON Schema object.","type":"invalid_request_error","code":null}}`)
+	out, err := newOpenAIClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_OpenAI_OutputIsValidErrorBodyShape(t *testing.T) {
+	bodies := [][]byte{
+		[]byte(`{"error":{"message":"Invalid function name","type":"invalid_request_error"}}`),
+		[]byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_error"}}`),
+		[]byte(`{}`),
+		[]byte(`not json`),
+	}
+	statuses := []int{400, 429, 500, 502}
+
+	c := newOpenAIClient()
+	for i, body := range bodies {
+		out, err := c.NormalizeError(statuses[i], body)
+		if err != nil {
+			t.Errorf("body[%d]: unexpected error: %v", i, err)
+			continue
+		}
+		var shape struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(out, &shape); err != nil {
+			t.Errorf("body[%d]: output is not valid JSON: %v", i, err)
+			continue
+		}
+		if shape.Error.Message == "" {
+			t.Errorf("body[%d]: error.message is empty", i)
+		}
+	}
+}

--- a/internal/providers/openaicompat/client_test.go
+++ b/internal/providers/openaicompat/client_test.go
@@ -1,0 +1,131 @@
+package openaicompat
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/marcoantonios1/costguard/internal/providers"
+)
+
+func parseErrorBody(t *testing.T, b []byte) providers.ErrorBody {
+	t.Helper()
+	var out providers.ErrorBody
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("failed to parse normalized error: %v\nbody: %s", err, b)
+	}
+	return out
+}
+
+func newCompatClient() *Client {
+	return &Client{}
+}
+
+// ---------------------------------------------------------------------------
+// Generic errors
+// ---------------------------------------------------------------------------
+
+func TestNormalizeError_Compat_PassthroughOpenAIShape(t *testing.T) {
+	body := []byte(`{"error":{"message":"Invalid API key.","type":"authentication_error"}}`)
+	out, err := newCompatClient().NormalizeError(http.StatusUnauthorized, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "authentication_error" {
+		t.Errorf("type: got %q, want authentication_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message != "Invalid API key." {
+		t.Errorf("message: got %q", parsed.Error.Message)
+	}
+}
+
+func TestNormalizeError_Compat_UnparsableBody(t *testing.T) {
+	body := []byte(`not json`)
+	out, err := newCompatClient().NormalizeError(http.StatusBadGateway, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "upstream_error" {
+		t.Errorf("type: got %q, want upstream_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty fallback message")
+	}
+}
+
+func TestNormalizeError_Compat_EmptyErrorMessage(t *testing.T) {
+	// Body has the right shape but empty message — fall through to status text.
+	body := []byte(`{"error":{"message":"","type":"some_error"}}`)
+	out, err := newCompatClient().NormalizeError(http.StatusInternalServerError, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty fallback message")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tool-related errors
+// ---------------------------------------------------------------------------
+
+func TestNormalizeError_Compat_InvalidToolName(t *testing.T) {
+	body := []byte(`{"error":{"message":"Invalid tool name: must not contain hyphens.","type":"invalid_request_error"}}`)
+	out, err := newCompatClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+	if parsed.Error.Message == "" {
+		t.Error("expected a non-empty message")
+	}
+}
+
+func TestNormalizeError_Compat_MalformedToolSchema(t *testing.T) {
+	body := []byte(`{"error":{"message":"tools[0].function.parameters must be a valid JSON Schema object.","type":"invalid_request_error"}}`)
+	out, err := newCompatClient().NormalizeError(http.StatusBadRequest, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseErrorBody(t, out)
+	if parsed.Error.Type != "invalid_request_error" {
+		t.Errorf("type: got %q, want invalid_request_error", parsed.Error.Type)
+	}
+}
+
+func TestNormalizeError_Compat_OutputIsValidErrorBodyShape(t *testing.T) {
+	bodies := [][]byte{
+		[]byte(`{"error":{"message":"Invalid tool name","type":"invalid_request_error"}}`),
+		[]byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_error"}}`),
+		[]byte(`{}`),
+		[]byte(`not json`),
+	}
+	statuses := []int{400, 429, 500, 502}
+
+	c := newCompatClient()
+	for i, body := range bodies {
+		out, err := c.NormalizeError(statuses[i], body)
+		if err != nil {
+			t.Errorf("body[%d]: unexpected error: %v", i, err)
+			continue
+		}
+		var shape struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(out, &shape); err != nil {
+			t.Errorf("body[%d]: output is not valid JSON: %v", i, err)
+			continue
+		}
+		if shape.Error.Message == "" {
+			t.Errorf("body[%d]: error.message is empty", i)
+		}
+	}
+}


### PR DESCRIPTION
- Gemini: map gRPC Status strings to OpenAI error types instead of always emitting "upstream_error". INVALID_ARGUMENT → invalid_request_error, RESOURCE_EXHAUSTED → rate_limit_error, UNAUTHENTICATED → authentication_error, PERMISSION_DENIED → permission_error, NOT_FOUND → not_found_error, INTERNAL/UNAVAILABLE → api_error.
- Tests (all four providers): generic error cases plus tool-specific scenarios (invalid tool name, malformed schema, argument errors, tool_use ID not found). Each suite also asserts the output always has a non-empty {"error":{"message":...}} envelope.